### PR TITLE
Fixed bug in PPO agent

### DIFF
--- a/burn-rl/src/agent/dqn/agent.rs
+++ b/burn-rl/src/agent/dqn/agent.rs
@@ -3,7 +3,7 @@ use crate::base::agent::Agent;
 use crate::base::environment::Environment;
 use crate::base::{get_batch, sample_indices, Action, Memory};
 use crate::utils::{
-    convert_tenor_to_action, ref_to_action_tensor, ref_to_not_done_tensor, ref_to_reward_tensor,
+    convert_tensor_to_action, ref_to_action_tensor, ref_to_not_done_tensor, ref_to_reward_tensor,
     ref_to_state_tensor, to_state_tensor, update_parameters,
 };
 use burn::module::AutodiffModule;
@@ -22,7 +22,7 @@ pub struct DQN<E: Environment, B: Backend, M: DQNModel<B>> {
 
 impl<E: Environment, B: Backend, M: DQNModel<B>> Agent<E> for DQN<E, B, M> {
     fn react(&self, state: &E::StateType) -> Option<E::ActionType> {
-        Some(convert_tenor_to_action::<E::ActionType, B>(
+        Some(convert_tensor_to_action::<E::ActionType, B>(
             self.target_net
                 .as_ref()?
                 .infer(ref_to_state_tensor(state).unsqueeze()),
@@ -52,7 +52,7 @@ impl<E: Environment, B: AutodiffBackend, M: DQNModel<B>> DQN<E, B, M> {
         eps_threshold: f64,
     ) -> E::ActionType {
         if random::<f64>() > eps_threshold {
-            convert_tenor_to_action::<E::ActionType, B>(
+            convert_tensor_to_action::<E::ActionType, B>(
                 policy_net.forward(to_state_tensor(state).unsqueeze()),
             )
         } else {

--- a/burn-rl/src/agent/ppo/agent.rs
+++ b/burn-rl/src/agent/ppo/agent.rs
@@ -98,7 +98,6 @@ impl<E: Environment, B: AutodiffBackend, M: PPOModel<B> + AutodiffModule<B>> PPO
                             .as_slice(),
                         &Default::default(),
                     );
-
                     let state_batch =
                         get_batch(memory.states(), &sample_indices, ref_to_state_tensor);
                     let action_batch =
@@ -195,11 +194,10 @@ pub(crate) fn get_gae<B: Backend>(
         returns[i] = running_return;
         advantages[i] = running_advantage;
     }
-
     Some(GAEOutput::new(
-        Tensor::<B, 2>::from_floats(returns.as_slice(), &Default::default())
+        Tensor::<B, 1>::from_floats(returns.as_slice(), &Default::default())
             .reshape([returns.len(), 1]),
-        Tensor::<B, 2>::from_floats(advantages.as_slice(), &Default::default())
+        Tensor::<B, 1>::from_floats(advantages.as_slice(), &Default::default())
             .reshape([advantages.len(), 1]),
     ))
 }

--- a/burn-rl/src/agent/sac/agent.rs
+++ b/burn-rl/src/agent/sac/agent.rs
@@ -4,7 +4,7 @@ use crate::base::agent::Agent;
 use crate::base::environment::Environment;
 use crate::base::{get_batch, sample_indices, Action, ElemType, Memory};
 use crate::utils::{
-    convert_tenor_to_action, elementwise_min, ref_to_action_tensor, ref_to_not_done_tensor,
+    convert_tensor_to_action, elementwise_min, ref_to_action_tensor, ref_to_not_done_tensor,
     ref_to_reward_tensor, ref_to_state_tensor, sample_action_from_tensor, to_state_tensor,
     update_parameters,
 };
@@ -71,7 +71,7 @@ impl<E: Environment, B: AutodiffBackend, Actor: SACActor<B>> SAC<E, B, Actor> {
         eps_threshold: f64,
     ) -> E::ActionType {
         if random::<f64>() > eps_threshold {
-            convert_tenor_to_action::<E::ActionType, B>(
+            convert_tensor_to_action::<E::ActionType, B>(
                 policy_net.forward(to_state_tensor(state).unsqueeze()),
             )
         } else {

--- a/burn-rl/src/utils/mod.rs
+++ b/burn-rl/src/utils/mod.rs
@@ -15,7 +15,7 @@ pub(crate) fn ref_to_state_tensor<S: State, B: Backend>(state: &S) -> Tensor<B, 
     to_state_tensor(*state)
 }
 
-pub(crate) fn convert_tenor_to_action<A: Action, B: Backend>(output: Tensor<B, 2>) -> A {
+pub(crate) fn convert_tensor_to_action<A: Action, B: Backend>(output: Tensor<B, 2>) -> A {
     (output.argmax(1).to_data().as_slice::<i64>().unwrap()[0] as u32).into()
 }
 

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -12,7 +12,7 @@ type Backend = Autodiff<NdArray<ElemType>>;
 type Env = CartPole;
 
 fn main() {
-    let agent = dqn::run::<Env, Backend>(512, false);
+    let agent = ppo::run::<Env, Backend>(512, false); //true);
 
     demo_model::<Env>(agent);
 }


### PR DESCRIPTION
# Description
A simple and easily fixable bug in the **PPO** agent.
## How to reproduce
Simply modify the `main()` function to run the experiment using the **PPO** agent instead of the default **DQN** agent.
```rust
fn main() {
    let agent = ppo::run::<Env, Backend>(1024, false); 

    demo_model::<Env>(agent);
}
```
## Stack trace
```
=== Tensor Operation Error ===
  Operation: 'From Data'
  Reason:
    1. Given dimensions differ from the tensor rank. Tensor rank: '2', given dimensions: '[39]'. 

stack backtrace:
   0:     0x556aa3f764ba - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hfc616348d9ad0abc
   1:     0x556aa3f98cd3 - core::fmt::write::h7ca648217bc79799
   2:     0x556aa3f73623 - std::io::Write::write_fmt::h7960c58bfa5ccbcb
   3:     0x556aa3f76302 - std::sys::backtrace::BacktraceLock::print::h3fb349e80cbe0423
   4:     0x556aa3f774b0 - std::panicking::default_hook::{{closure}}::h3366e5842cba645d
   5:     0x556aa3f77290 - std::panicking::default_hook::hd7573a5d4879884b
   6:     0x556aa3f77c12 - std::panicking::rust_panic_with_hook::h66e909d048c263a9
   7:     0x556aa3f779ba - std::panicking::begin_panic_handler::{{closure}}::h8d9aa8be7e8634cf
   8:     0x556aa3f769c9 - std::sys::backtrace::__rust_end_short_backtrace::h7d7e47ef99abf6aa
   9:     0x556aa3f7764d - rust_begin_unwind
  10:     0x556aa3da9200 - core::panicking::panic_fmt::hf8ffc7c15bfb58a0
  11:     0x556aa3d9e248 - burn_tensor::tensor::api::base::Tensor<B,_,K>::from_data::panic_cold_display::hd024a2ac87bd9aa6
  12:     0x556aa3e7985a - burn_tensor::tensor::api::float::<impl burn_tensor::tensor::api::base::Tensor<B,_>>::from_floats::h7be1b46e58acd006
  13:     0x556aa3e8b968 - burn_rl::agent::ppo::agent::PPO<E,B,M>::train::h6be7ad76e2e9f817
  14:     0x556aa3ee33dd - burn_rl_examples::ppo::run::hac871d32407ccbf1
  15:     0x556aa3edb4fa - burn_rl_examples::main::hb06a3bb152a6d952
  16:     0x556aa3eeaec3 - std::sys::backtrace::__rust_begin_short_backtrace::h6328d0d22448c02e
  17:     0x556aa3eb8979 - std::rt::lang_start::{{closure}}::hcf0abf4a0a22f41b
  18:     0x556aa3f6e1e7 - std::rt::lang_start_internal::heee0af441e41a6d2
  19:     0x556aa3edb535 - main
  20:     0x7f97a27235f5 - __libc_start_call_main
  21:     0x7f97a27236a8 - __libc_start_main_impl
  22:     0x556aa3da9865 - _start
  23:                0x0 - <unknown>
```
## Origin
The issue stems from the `get_gae()` function in the **PPO** agent, where the tensor rank is incorrectly specified:
```rust
Some(GAEOutput::new(
        Tensor::<B, 2>::from_floats(returns.as_slice(), &Default::default())
            .reshape([returns.len(), 1]),
        Tensor::<B, 2>::from_floats(advantages.as_slice(), &Default::default())
            .reshape([advantages.len(), 1]),
    ))
```
## Solution
This is an easy fix! A simple correction to the generic dimensions used when creating the tensors from the `Vec` is enough to resolve the bug.
```rust
Some(GAEOutput::new(
        Tensor::<B, 1>::from_floats(returns.as_slice(), &Default::default())
            .reshape([returns.len(), 1]),
        Tensor::<B, 1>::from_floats(advantages.as_slice(), &Default::default())
            .reshape([advantages.len(), 1]),
    ))
```
## Secondary Stuff
Also, I corrected a spelling error by adding a missing "s": from `convert_tenor_to_action()` to `convert_tensor_to_action()`.

:)